### PR TITLE
TO-26-Bugfix-Linebreak-Eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
   plugins: ["vue"],
   rules: {
     indent: ["error", 2],
-    "linebreak-style": ["error", "windows"],
     quotes: ["error", "double"],
     semi: ["error", "always"],
     "vue/multi-word-component-names": "off",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "vue-router": "^3.5.1",
     "vuetify": "^2.6.0",
     "vuex": "^3.6.2",
-    "vuex-persistedstate": "^4.1.0"
-  },
-  "devDependencies": {
+    "vuex-persistedstate": "^4.1.0",
     "@babel/core": "^7.12.16",
     "@babel/eslint-parser": "^7.12.16",
     "@vue/cli-plugin-babel": "~5.0.0",


### PR DESCRIPTION
Corrigido erro com o CI do heroku que não aceita os `linebreaks` de Windows configurados no ESlint